### PR TITLE
Add a list of links to presentation files.

### DIFF
--- a/PRESENTATIONS.md
+++ b/PRESENTATIONS.md
@@ -1,0 +1,59 @@
+# List of presentations
+
+This is a list of files accompanying presentations given at past Ljubljana
+Python Meetups. Files are listed in chronological order. Special thanks to
+authors who were willing to share their work.
+
+## 2019
+
+### 22 July
+
+ * Mitja Nemec, [My journey as a Python plugin developer for KiCad](https://speakerdeck.com/mitjan/my-journey-as-a-python-plugin-developer-for-kicad)
+ * Roman Luštrik, [AWS triggered - a short foray into Lambda functions and S3 buckets](https://docs.google.com/presentation/d/1lrGC1DBU1ToDcg9L06cOHTeJ3aQC8RdQXI479djvGIY/edit#slide=id.g4d9234a311_2_45)
+
+### 13 June
+
+ * Tomaž Šolc, [Python classes as namespaces](https://www.tablix.org/~avian/blog/articles/talks/python_classes_as_namespaces.pdf)
+
+### 22 May
+
+ * Sara Jakša, [Making Sense of Text: What Topic Modeling Can Tell Us About Python Discussions on Tumblr](http://sarajaksa.eu/content/presentations/2019/ljubljana-python-meetup-may-2019/)
+
+### 24 April
+
+ * Martin Cimerman, [Parallel Python jobs with Kubernetes](https://docs.google.com/presentation/d/13FW-j2kEulDkrXxBBySwUg_NH8aD1KPjyL63AlR7x0I/edit?usp=sharing)
+ * Matjaž Drolc, [Serverless Jupyter](https://drive.google.com/file/d/1uRS9askiukTpovFl_2KYArdxl6QWS8vU/view)
+ * Jure Čuhalev, [Idling in chat apps can be good for you](https://www.dropbox.com/s/khya0ktds6ul9sl/ChatAppsLightningTalks.pdf?dl=0)
+
+### 19 March
+
+ * Roman Luštrik, [Static websites are (still) the rage - Pelican static page generator](https://docs.google.com/presentation/d/1-61-3hebyWacIqG3z-zYT9d6Zev-GWSBeLWPgfzhjPs/edit#slide=id.g4d9234a311_2_45)
+ * Tim Vakselj, [Magic: The Gathering](https://docs.google.com/presentation/d/161spaedE_c_b-u78M4poUCkrst_dtCGc73fAEbwT_u0/edit#slide=id.p)
+
+### 19 February
+
+ * Jure Čuhalev, [Supervisord and superlance](https://www.dropbox.com/s/9331jkp6dczeemv/SupervisordLightningTalk.pdf?dl=0)
+ * Sara Jakša, [Segregation of People into Like-Minded Groups](https://github.com/sarajaksa/DataAnalysis/blob/master/Segregation%20of%20People%20into%20Like-Minded%20Groups%20%5BPython%20MeetUp%20Ljubljana%20February%202019%5D.ipynb)
+
+### 17 January
+
+ * Roman Luštrik, [Using docker package for running (oddball) jobs from Python](https://docs.google.com/presentation/d/165emx5Bi1FQNLgq6Yo3m-IVkN1qsciI9qdrxHtdVNoI/edit#slide=id.g4d9234a311_2_45)
+ * kernc, [Hijacking a mismanaged project](https://kernc.github.io/slid.es/meetup-ljpy-pdoc/)
+
+## 2018
+
+### 15 November
+
+ * Jure Čuhalev, [Self-code reviews with CI](https://www.dropbox.com/s/y5xd2hx8vhqjnjw/SelfCodeReviewsLightningTalk.pdf?dl=0)
+
+### 20 September
+
+ * Tomaž Šolc, [Extending GIMP with Python](https://www.tablix.org/~avian/blog/articles/talks/extending_gimp_python.pdf)
+
+## 2017
+
+### 20 July
+
+ * Tomaž Šolc, [Merging structured data with jsonmerge](https://www.tablix.org/~avian/blog/articles/talks/tomaz_solc_jsonmerge.pdf)
+
+

--- a/README.md
+++ b/README.md
@@ -6,6 +6,8 @@ Recent and upcoming events: https://www.meetup.com/Ljubljana-Python-Group/
 
 List of [previous and upcoming talks](https://github.com/ljpy/meetups/issues/1).
 
+Links to [presentation files](https://github.com/ljpy/meetups/blob/master/PRESENTATIONS.md).
+
 List of [past and potential future sponsors](https://github.com/ljpy/meetups/issues/2).
 
 Find us under the [#ljpy](https://twitter.com/search?q=%23ljpy) hashtag on socials!


### PR DESCRIPTION
I went back through the past meetups and aggregated links to presentation files
that are still on-line. I'm not sure if this was meant by @zupo in #32. I think
having them in a separate file makes them more visible than leaving them in
old, closed GitHub issues (e.g. #30).